### PR TITLE
refactor: use typed Prometheus family descriptors

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
@@ -42,6 +42,7 @@ import io.prometheus.metrics.model.snapshots.HistogramSnapshot.HistogramDataPoin
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot.InfoDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
 import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
@@ -51,6 +52,7 @@ import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.Unit;
+import io.prometheus.metrics.model.registry.MetricType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -470,7 +472,7 @@ final class Otel2PrometheusConverter {
 
   private InfoSnapshot makeTargetInfo(Resource resource) {
     return new InfoSnapshot(
-        new MetricMetadata("target"),
+        MetricFamilyDescriptor.info("target").build().getMetadata(),
         Collections.singletonList(
             new InfoDataPointSnapshot(
                 convertAttributes(
@@ -679,20 +681,22 @@ final class Otel2PrometheusConverter {
   }
 
   private MetricMetadata convertMetadata(MetricData metricData, boolean isCounter) {
+    MetricType metricType = getMetricType(metricData, isCounter);
     switch (translationStrategy) {
       case UNDERSCORE_ESCAPING_WITH_SUFFIXES:
-        return convertMetadataEscapedWithSuffixes(metricData);
+        return convertMetadataEscapedWithSuffixes(metricData, metricType);
       case UNDERSCORE_ESCAPING_WITHOUT_SUFFIXES:
         return convertMetadataEscapedWithoutSuffixes(metricData);
       case NO_UTF8_ESCAPING_WITH_SUFFIXES:
-        return convertMetadataUtf8WithSuffixes(metricData, isCounter);
+        return convertMetadataUtf8WithSuffixes(metricData, metricType);
       case NO_TRANSLATION:
         return convertMetadataNoTranslation(metricData);
     }
     throw new IllegalStateException("Unknown strategy: " + translationStrategy);
   }
 
-  private static MetricMetadata convertMetadataEscapedWithSuffixes(MetricData metricData) {
+  private static MetricMetadata convertMetadataEscapedWithSuffixes(
+      MetricData metricData, MetricType metricType) {
     String originalName = metricData.getName();
     String name = stripReservedMetricSuffixes(convertLegacyMetricName(originalName));
     String help = metricData.getDescription();
@@ -701,7 +705,7 @@ final class Otel2PrometheusConverter {
       name = name + "_" + unit;
     }
     validateNormalizedMetricName(originalName, name);
-    return new MetricMetadata(name, name, name, help, unit);
+    return buildMetricFamilyDescriptor(metricType, name, help, unit).getMetadata();
   }
 
   private static MetricMetadata convertMetadataEscapedWithoutSuffixes(MetricData metricData) {
@@ -713,18 +717,14 @@ final class Otel2PrometheusConverter {
   }
 
   private static MetricMetadata convertMetadataUtf8WithSuffixes(
-      MetricData metricData, boolean isCounter) {
+      MetricData metricData, MetricType metricType) {
     String name = metricData.getName();
     String help = metricData.getDescription();
     Unit unit = PrometheusUnitsHelper.convertUnit(metricData.getUnit());
     if (unit != null && !name.endsWith(unit.toString())) {
       name = name + "_" + unit;
     }
-    String expositionBaseName = name;
-    if (isCounter && !expositionBaseName.endsWith("_total")) {
-      expositionBaseName = expositionBaseName + "_total";
-    }
-    return new MetricMetadata(stripReservedMetricSuffixes(name), expositionBaseName, help, unit);
+    return buildMetricFamilyDescriptor(metricType, name, help, unit).getMetadata();
   }
 
   private static MetricMetadata convertMetadataNoTranslation(MetricData metricData) {
@@ -860,6 +860,33 @@ final class Otel2PrometheusConverter {
       return null;
     }
     return new MetricMetadata(name, help, unit);
+  }
+
+  private static MetricType getMetricType(MetricData metricData, boolean isCounter) {
+    switch (metricData.getType()) {
+      case LONG_GAUGE:
+      case DOUBLE_GAUGE:
+        return MetricType.GAUGE;
+      case LONG_SUM:
+      case DOUBLE_SUM:
+        return isCounter ? MetricType.COUNTER : MetricType.GAUGE;
+      case HISTOGRAM:
+      case EXPONENTIAL_HISTOGRAM:
+        return MetricType.HISTOGRAM;
+      case SUMMARY:
+        return MetricType.SUMMARY;
+    }
+    throw new IllegalStateException("Unknown metric type: " + metricData.getType());
+  }
+
+  private static MetricFamilyDescriptor buildMetricFamilyDescriptor(
+      MetricType metricType, String name, @Nullable String help, @Nullable Unit unit) {
+    MetricFamilyDescriptor.Builder<?> builder =
+        MetricFamilyDescriptor.of(metricType, name).help(help);
+    if (unit != null) {
+      builder.unit(unit);
+    }
+    return builder.build();
   }
 
   private static String typeString(MetricSnapshot snapshot) {

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
@@ -198,10 +198,7 @@ class Otel2PrometheusConverterTest {
   @ParameterizedTest
   @MethodSource("translationStrategyArgs")
   void metricMetadata_translationStrategy(
-      TranslationStrategy translationStrategy,
-      String expectedName,
-      String expectedExpositionBaseName,
-      String expectedOriginalName) {
+      TranslationStrategy translationStrategy, String expectedName) {
     Otel2PrometheusConverter converter =
         new Otel2PrometheusConverter(
             /* otelScopeLabelsEnabled= */ true,
@@ -216,29 +213,14 @@ class Otel2PrometheusConverterTest {
 
     MetricMetadata metadata = snapshots.get(0).getMetadata();
     assertThat(metadata.getName()).isEqualTo(expectedName);
-    assertThat(metadata.getExpositionBaseName()).isEqualTo(expectedExpositionBaseName);
-    assertThat(metadata.getOriginalName()).isEqualTo(expectedOriginalName);
   }
 
   private static Stream<Arguments> translationStrategyArgs() {
     return Stream.of(
-        Arguments.of(
-            TranslationStrategy.UNDERSCORE_ESCAPING_WITH_SUFFIXES,
-            "sample_name_bytes",
-            "sample_name_bytes",
-            "sample_name_bytes"),
-        Arguments.of(
-            TranslationStrategy.UNDERSCORE_ESCAPING_WITHOUT_SUFFIXES,
-            "sample_name",
-            "sample_name",
-            "sample_name"),
-        Arguments.of(
-            TranslationStrategy.NO_UTF8_ESCAPING_WITH_SUFFIXES,
-            "sample.name_bytes",
-            "sample.name_bytes_total",
-            "sample.name_bytes_total"),
-        Arguments.of(
-            TranslationStrategy.NO_TRANSLATION, "sample.name", "sample.name", "sample.name"));
+        Arguments.of(TranslationStrategy.UNDERSCORE_ESCAPING_WITH_SUFFIXES, "sample_name_bytes"),
+        Arguments.of(TranslationStrategy.UNDERSCORE_ESCAPING_WITHOUT_SUFFIXES, "sample_name"),
+        Arguments.of(TranslationStrategy.NO_UTF8_ESCAPING_WITH_SUFFIXES, "sample.name_bytes"),
+        Arguments.of(TranslationStrategy.NO_TRANSLATION, "sample.name"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Stacked on top of #8346.

This refactors the Prometheus exporter to use the new typed `client_java`
family descriptor API where the translation strategy already matches typed
Prometheus family semantics.

Depends on:
- open-telemetry/opentelemetry-java#8346
- prometheus/client_java#2114

## What changed

- use `MetricFamilyDescriptor` for `target_info`
- use `MetricFamilyDescriptor` when deriving metadata for:
  - `UNDERSCORE_ESCAPING_WITH_SUFFIXES`
  - `NO_UTF8_ESCAPING_WITH_SUFFIXES`
- keep the legacy direct `MetricMetadata` construction paths for the
  no-suffix translation modes for now
- update the metadata translation test to reflect the typed descriptor-backed
  metadata shape for UTF-8 counter translation

## Why

`#8346` expands translation-strategy support, but the exporter still manually
constructs Prometheus `MetricMetadata` in the conversion path.

With `client_java#2114`, the Prometheus-semantic translation modes can rely on
upstream typed metadata derivation instead of rebuilding those rules locally.

The no-suffix translation modes are intentionally left on the compatibility
path for now because they do not map cleanly to typed counter semantics.

## Validation

Tested locally against a locally installed `prometheus/client_java`
`1.6.2-SNAPSHOT` containing `MetricFamilyDescriptor` from
`prometheus/client_java#2114`:

```bash
./gradlew --no-build-cache \
  -I /tmp/otel-prom-local.init.gradle \
  :exporters:prometheus:test \
  --tests io.opentelemetry.exporter.prometheus.Otel2PrometheusConverterTest \
  --tests io.opentelemetry.exporter.prometheus.PrometheusMetricReaderTest \
  --tests io.opentelemetry.exporter.prometheus.PrometheusHttpServerTest
```

## Notes

- This is a stacked draft for review of the direction, not something expected
  to pass upstream CI before the `client_java` API lands in a published
  dependency.
